### PR TITLE
Fix Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM node:16-alpine
+FROM node:16.14.2-alpine
 
-WORKDIR /work
+COPY . /usr/app
+WORKDIR /usr/app
 
-ADD package* ./
 RUN npm ci
-
-ADD . .
 RUN npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "vitest-mock-error",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
This fixes your docker build. I suspect the issue may lie in how Vite handles module resolution. Regardless it is always good process to set your workdir inside /usr/ as opposed to somewhere on root. 